### PR TITLE
refactor: Decompose App.tsx into smaller components

### DIFF
--- a/ponkotsu-svg-generator/src/components/Shape.tsx
+++ b/ponkotsu-svg-generator/src/components/Shape.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import type { ShapeData } from '../App';
+
+interface ShapeProps {
+  shape: ShapeData;
+  isSelected: boolean;
+  onClick: (e: React.MouseEvent) => void;
+}
+
+const Shape: React.FC<ShapeProps> = ({ shape, isSelected, onClick }) => {
+  // For now, we only handle rectangles.
+  // In the future, we can add a switch statement here based on shape.type
+  if (shape.type === 'rectangle') {
+    return (
+      <rect
+        key={shape.id}
+        x={shape.x}
+        y={shape.y}
+        width={shape.width}
+        height={shape.height}
+        fill="none"
+        stroke={isSelected ? 'blue' : 'black'}
+        strokeWidth={2}
+        onClick={onClick}
+        style={{ cursor: 'pointer' }}
+      />
+    );
+  }
+
+  return null; // Or render a placeholder for unknown shapes
+};
+
+export default Shape;

--- a/ponkotsu-svg-generator/src/components/SvgCanvas.tsx
+++ b/ponkotsu-svg-generator/src/components/SvgCanvas.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import type { ShapeData } from '../App';
+import Shape from './Shape';
+
+interface SvgCanvasProps {
+  shapes: ShapeData[];
+  drawingState: ShapeData | null;
+  selectedShapeId: string | null;
+  onMouseDown: (e: React.MouseEvent) => void;
+  onMouseMove: (e: React.MouseEvent) => void;
+  onMouseUp: (e: React.MouseEvent) => void;
+  onMouseLeave: (e: React.MouseEvent) => void;
+  onCanvasClick: () => void;
+  onShapeClick: (id: string, e: React.MouseEvent) => void;
+}
+
+const SvgCanvas = React.forwardRef<SVGSVGElement, SvgCanvasProps>(
+  (
+    {
+      shapes,
+      drawingState,
+      selectedShapeId,
+      onMouseDown,
+      onMouseMove,
+      onMouseUp,
+      onMouseLeave,
+      onCanvasClick,
+      onShapeClick,
+    },
+    ref
+  ) => {
+    return (
+      <svg
+        ref={ref}
+        width={800}
+        height={600}
+        style={{ border: '1px solid black' }}
+        onClick={onCanvasClick}
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={onMouseUp}
+        onMouseLeave={onMouseLeave}
+      >
+        {shapes.map((shape) => (
+          <Shape
+            key={shape.id}
+            shape={shape}
+            isSelected={selectedShapeId === shape.id}
+            onClick={(e) => onShapeClick(shape.id, e)}
+          />
+        ))}
+        {drawingState && (
+          <rect
+            x={drawingState.x}
+            y={drawingState.y}
+            width={drawingState.width}
+            height={drawingState.height}
+            fill="none"
+            stroke="black"
+            strokeWidth={1}
+            strokeDasharray="5,5"
+          />
+        )}
+      </svg>
+    );
+  }
+);
+
+export default SvgCanvas;

--- a/ponkotsu-svg-generator/src/components/Toolbar.tsx
+++ b/ponkotsu-svg-generator/src/components/Toolbar.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+interface ToolbarProps {
+  onClear: () => void;
+  onExport: () => void;
+  shapesCount: number;
+}
+
+const Toolbar: React.FC<ToolbarProps> = ({ onClear, onExport, shapesCount }) => {
+  return (
+    <div className="controls">
+      <button onClick={onClear}>クリア</button>
+      <button onClick={onExport} disabled={shapesCount === 0}>エクスポート</button>
+    </div>
+  );
+};
+
+export default Toolbar;


### PR DESCRIPTION
Refactors the monolithic App.tsx into three distinct components to improve maintainability and prepare for future extensions.

- App.tsx: Now acts as a container, managing state and orchestrating child components.
- Toolbar.tsx: A new component for UI controls (Clear, Export).
- SvgCanvas.tsx: A new component that handles the SVG drawing canvas and mouse events.
- Shape.tsx: A new component for rendering individual shapes (named generically for future extensibility).

The data structure has also been made more generic (ShapeData) to accommodate future shapes beyond rectangles.