### PR TITLE
Refactor: Extract logic into custom hooks

### DIFF
--- a/ponkotsu-svg-generator/src/App.tsx
+++ b/ponkotsu-svg-generator/src/App.tsx
@@ -1,7 +1,10 @@
-import { useReducer, useRef, useEffect } from 'react';
+import { useReducer, useRef } from 'react';
 import Toolbar from './components/Toolbar';
 import SvgCanvas from './components/SvgCanvas';
 import { reducer, initialState } from './state/reducer';
+import { useDrawing } from './hooks/useDrawing';
+import { useKeyboardControls } from './hooks/useKeyboardControls';
+import { useSvgExport } from './hooks/useSvgExport';
 import './App.css'
 
 // Type for a single shape data
@@ -18,79 +21,14 @@ function App() {
   const [state, dispatch] = useReducer(reducer, initialState);
   const { shapes, selectedShapeId, drawingState } = state;
 
-  // Ref for the SVG element itself, used for getting mouse position and for export
   const svgRef = useRef<SVGSVGElement>(null);
 
-  // Ref to track if the user is currently drawing
-  const isDrawing = useRef(false);
-  const startPoint = useRef({ x: 0, y: 0 });
-
-  const getMousePosition = (e: React.MouseEvent): { x: number, y: number } => {
-    if (svgRef.current) {
-      const CTM = svgRef.current.getScreenCTM();
-      if (CTM) {
-        return {
-          x: (e.clientX - CTM.e) / CTM.a,
-          y: (e.clientY - CTM.f) / CTM.d
-        };
-      }
-    }
-    return { x: 0, y: 0 };
-  };
-
-  const handleMouseDown = (e: React.MouseEvent) => {
-    // Prevent drawing when clicking on an existing shape
-    if ((e.target as SVGElement).closest('rect')) {
-        return;
-    }
-    isDrawing.current = true;
-    const pos = getMousePosition(e);
-    startPoint.current = pos;
-    dispatch({ type: 'START_DRAWING', payload: pos });
-  };
-
-  const handleMouseMove = (e: React.MouseEvent) => {
-    if (!isDrawing.current) return;
-
-    const pos = getMousePosition(e);
-    dispatch({
-        type: 'DRAWING',
-        payload: { x: pos.x, y: pos.y, startX: startPoint.current.x, startY: startPoint.current.y },
-    });
-  };
-
-  const handleMouseUp = () => {
-    if (!isDrawing.current) return;
-    isDrawing.current = false;
-    dispatch({ type: 'END_DRAWING' });
-  };
+  const { handleMouseDown, handleMouseMove, handleMouseUp } = useDrawing(dispatch, svgRef);
+  useKeyboardControls(dispatch, selectedShapeId);
+  const { handleExport } = useSvgExport(svgRef);
 
   const handleClear = () => {
     dispatch({ type: 'CLEAR_CANVAS' });
-  };
-
-  const handleExport = () => {
-    if (svgRef.current) {
-      // Create a clone of the SVG node to avoid modifying the one in the DOM
-      const svgNode = svgRef.current.cloneNode(true) as SVGSVGElement;
-
-      // Add the required xmlns attribute for standalone SVG files
-      svgNode.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-
-      // Set a background color for the exported SVG
-      svgNode.style.backgroundColor = 'white';
-
-      const svgContent = svgNode.outerHTML;
-      const blob = new Blob([svgContent], { type: 'image/svg+xml' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'ponkotsu.svg';
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-    }
   };
 
   const handleCanvasClick = () => {
@@ -98,24 +36,9 @@ function App() {
   };
 
   const handleShapeClick = (id: string, e: React.MouseEvent) => {
-    e.stopPropagation(); // Prevent canvas click from firing
+    e.stopPropagation();
     dispatch({ type: 'SELECT_SHAPE', payload: id });
   };
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.key === 'Delete' || e.key === 'Backspace') && selectedShapeId) {
-        dispatch({ type: 'DELETE_SELECTED_SHAPE' });
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-
-    // Cleanup function to remove the event listener
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [selectedShapeId]); // Dependency array ensures the effect re-runs if selectedShapeId changes
 
   return (
     <div className="App">

--- a/ponkotsu-svg-generator/src/hooks/useDrawing.ts
+++ b/ponkotsu-svg-generator/src/hooks/useDrawing.ts
@@ -1,0 +1,55 @@
+import { useRef } from 'react';
+import { Action } from '../state/reducer';
+
+export const useDrawing = (
+  dispatch: React.Dispatch<Action>,
+  svgRef: React.RefObject<SVGSVGElement>
+) => {
+  const isDrawing = useRef(false);
+  const startPoint = useRef({ x: 0, y: 0 });
+
+  const getMousePosition = (e: React.MouseEvent): { x: number, y: number } => {
+    if (svgRef.current) {
+      const CTM = svgRef.current.getScreenCTM();
+      if (CTM) {
+        return {
+          x: (e.clientX - CTM.e) / CTM.a,
+          y: (e.clientY - CTM.f) / CTM.d
+        };
+      }
+    }
+    return { x: 0, y: 0 };
+  };
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if ((e.target as SVGElement).closest('rect')) {
+      return;
+    }
+    isDrawing.current = true;
+    const pos = getMousePosition(e);
+    startPoint.current = pos;
+    dispatch({ type: 'START_DRAWING', payload: pos });
+  };
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!isDrawing.current) return;
+
+    const pos = getMousePosition(e);
+    dispatch({
+      type: 'DRAWING',
+      payload: { x: pos.x, y: pos.y, startX: startPoint.current.x, startY: startPoint.current.y },
+    });
+  };
+
+  const handleMouseUp = () => {
+    if (!isDrawing.current) return;
+    isDrawing.current = false;
+    dispatch({ type: 'END_DRAWING' });
+  };
+
+  return {
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+  };
+};

--- a/ponkotsu-svg-generator/src/hooks/useKeyboardControls.ts
+++ b/ponkotsu-svg-generator/src/hooks/useKeyboardControls.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { Action } from '../state/reducer';
+
+export const useKeyboardControls = (
+  dispatch: React.Dispatch<Action>,
+  selectedShapeId: string | null
+) => {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.key === 'Delete' || e.key === 'Backspace') && selectedShapeId) {
+        dispatch({ type: 'DELETE_SELECTED_SHAPE' });
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [selectedShapeId, dispatch]);
+};

--- a/ponkotsu-svg-generator/src/hooks/useSvgExport.ts
+++ b/ponkotsu-svg-generator/src/hooks/useSvgExport.ts
@@ -1,0 +1,24 @@
+import { RefObject } from 'react';
+
+export const useSvgExport = (svgRef: RefObject<SVGSVGElement>) => {
+  const handleExport = () => {
+    if (svgRef.current) {
+      const svgNode = svgRef.current.cloneNode(true) as SVGSVGElement;
+      svgNode.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+      svgNode.style.backgroundColor = 'white';
+
+      const svgContent = svgNode.outerHTML;
+      const blob = new Blob([svgContent], { type: 'image/svg+xml' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'ponkotsu.svg';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }
+  };
+
+  return { handleExport };
+};


### PR DESCRIPTION
This refactoring extracts the drawing, keyboard controls, and SVG export logic from App.tsx into three separate custom hooks:

- `useDrawing`: Handles all mouse-related drawing logic.
- `useKeyboardControls`: Manages keyboard events for deleting shapes.
- `useSvgExport`: Contains the logic for exporting the SVG canvas.

This change improves code organization and readability by separating concerns, making the App.tsx component cleaner and easier to maintain.