### PR TITLE
refactor: Consolidate ShapeData type definition

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,12 @@
 import { useReducer, useRef, useCallback } from 'react';
 import Toolbar from './components/Toolbar';
 import SvgCanvas from './components/SvgCanvas';
-import { reducer, initialState } from './state/reducer';
+import { reducer, initialState, type ShapeData } from './state/reducer';
 import { undoable } from './state/historyReducer';
 import { useDrawing } from './hooks/useDrawing';
 import { useKeyboardControls } from './hooks/useKeyboardControls';
 import { useSvgExport } from './hooks/useSvgExport';
-import './App.css'
-
-// Type for a single shape data
-export interface ShapeData {
-  id: string; // Unique ID for each shape
-  type: 'rectangle';
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}
+import './App.css';
 
 const undoableReducer = undoable(reducer);
 

--- a/src/components/Shape.tsx
+++ b/src/components/Shape.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ShapeData } from '../App';
+import type { ShapeData } from '../state/reducer';
 
 interface ShapeProps {
   shape: ShapeData;

--- a/src/components/SvgCanvas.tsx
+++ b/src/components/SvgCanvas.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ShapeData } from '../App';
+import type { ShapeData } from '../state/reducer';
 import Shape from './Shape';
 
 interface SvgCanvasProps {


### PR DESCRIPTION
Refactors the codebase to have a single source of truth for the `ShapeData` type.

The `ShapeData` interface was previously defined in both `App.tsx` and `src/state/reducer.ts`. This commit removes the duplicate definition from `App.tsx`.

All dependent files (`App.tsx`, `Shape.tsx`, `SvgCanvas.tsx`) now import the type from `src/state/reducer.ts`. This improves maintainability and adheres to the DRY principle.