### PR TITLE
ツールボックスのボタンを機能ごとにグループ化し、UIを改善しました。

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,13 +4,40 @@
 }
 
 .controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   margin: 1rem;
 }
 
+.tool-group {
+  display: inline-flex;
+  align-items: center;
+  border-right: 1px solid #ccc;
+  padding: 0 1rem;
+  margin: 0;
+}
+
+.tool-group:last-child {
+  border-right: none;
+}
+
 button {
-  margin: 0 0.5rem;
+  margin: 0 0.25rem;
   padding: 0.5rem 1rem;
   font-size: 1rem;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #f0f0f0;
+}
+
+button.active {
+  background-color: #e0f7ff;
+  border-color: #007bff;
 }
 
 svg {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -29,10 +29,6 @@ const Toolbar: React.FC<ToolbarProps> = ({
   return (
     <div className="controls">
       <div className="tool-group">
-        <button onClick={onUndo} disabled={!canUndo}>Undo</button>
-        <button onClick={onRedo} disabled={!canRedo}>Redo</button>
-      </div>
-      <div className="tool-group">
         <button
           onClick={() => onToolSelect('rectangle')}
           className={isActive('rectangle') ? 'active' : ''}
@@ -53,8 +49,14 @@ const Toolbar: React.FC<ToolbarProps> = ({
         </button>
       </div>
       <div className="tool-group">
-        <button onClick={onClear}>クリア</button>
+        <button onClick={onUndo} disabled={!canUndo}>Undo</button>
+        <button onClick={onRedo} disabled={!canRedo}>Redo</button>
+      </div>
+      <div className="tool-group">
         <button onClick={onExport} disabled={shapesCount === 0}>エクスポート</button>
+      </div>
+      <div className="tool-group">
+        <button onClick={onClear}>クリア</button>
       </div>
     </div>
   );


### PR DESCRIPTION
- 図形、Undo/Redo、エクスポート、クリアの各機能でボタンをグループ化
- グループ間に区切り線を追加し、視覚的なまとまりを向上
- 選択中のツールが色でハイライトされるようにスタイルを追加
- これにより、初期起動時に長方形ツールが選択されていることが明確になりました