### PR TITLE
🧹 [code health] Remove unused type import in SvgCanvas.tsx

### DIFF
--- a/src/components/SvgCanvas.tsx
+++ b/src/components/SvgCanvas.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react';
-import type { ShapeData, DrawingShape } from '../types'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { AppContext } from '../state/AppContext';
 import Shape from './Shape';
 import { useInteractionManager } from '../hooks/useInteractionManager';


### PR DESCRIPTION
🎯 **What:** Removed unused `ShapeData` and `DrawingShape` type imports and the accompanying eslint disable comment in `src/components/SvgCanvas.tsx`.
💡 **Why:** Clean up code health, reduce clutter, and improve readability. The imports were unneeded since those types were not used in the file.
✅ **Verification:** Verified by running `pnpm run lint`, test suite (`pnpm run test`), and build (`pnpm run build`). All checks passed successfully.
✨ **Result:** Improved codebase maintainability by getting rid of dead code.

---
*PR created automatically by Jules for task [1469605645156647983](https://jules.google.com/task/1469605645156647983) started by @morinatsu*