### PR TITLE
🔒 Fix sensitive state leakage in debug JSON export

### DIFF
--- a/src/components/DebugInfo.test.tsx
+++ b/src/components/DebugInfo.test.tsx
@@ -99,4 +99,44 @@ describe('DebugInfo', () => {
 
     expect(globalThis.URL.revokeObjectURL).toHaveBeenCalledWith('mock-url');
   });
+
+  it('redacts sensitive information when exporting JSON', async () => {
+    const appendChildSpy = vi.spyOn(document.body, 'appendChild');
+    vi.spyOn(document.body, 'removeChild');
+    vi.spyOn(HTMLAnchorElement.prototype, 'click');
+
+    const historyWithSensitiveData: HistoryState = {
+      ...mockHistory,
+      present: {
+        ...mockHistory.present,
+        // @ts-expect-error - simulating a potential leak of untyped state
+        password: 'my-super-secret-password',
+        // @ts-expect-error - simulating a potential leak of untyped state
+        apiKey: '12345-abcde',
+        // @ts-expect-error - simulating a potential leak of untyped state
+        authToken: 'jwt-token-string',
+        // @ts-expect-error - simulating a potential leak of untyped state
+        normalData: 'should-not-be-redacted'
+      },
+    };
+
+    render(<DebugInfo history={historyWithSensitiveData} />);
+    appendChildSpy.mockClear();
+
+    const exportButtons = screen.getAllByText('Export JSON');
+    // Click the second one (Present)
+    fireEvent.click(exportButtons[1]);
+
+    const blob = (globalThis.URL.createObjectURL as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as Blob;
+
+    const text = await blob.text();
+    const parsed = JSON.parse(text);
+
+    expect(parsed.password).toBe('[REDACTED]');
+    expect(parsed.apiKey).toBe('[REDACTED]');
+    expect(parsed.authToken).toBe('[REDACTED]');
+    expect(parsed.normalData).toBe('should-not-be-redacted');
+    expect(parsed.canvasWidth).toBe(800);
+  });
 });

--- a/src/components/DebugInfo.tsx
+++ b/src/components/DebugInfo.tsx
@@ -60,7 +60,15 @@ const DebugSection: React.FC<DebugSectionProps> = ({ label, data, filename }) =>
 
   const handleExport = () => {
     try {
-      const jsonString = JSON.stringify(data, null, 2);
+      const sensitiveKeys = /(password|token|secret|auth|key|credential|cookie)/i;
+      const replacer = (key: string, value: unknown) => {
+        if (sensitiveKeys.test(key) && typeof value === 'string') {
+          return '[REDACTED]';
+        }
+        return value;
+      };
+
+      const jsonString = JSON.stringify(data, replacer, 2);
       const blob = new Blob([jsonString], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a potential sensitive state leakage in the `DebugInfo` component's JSON export functionality.

⚠️ **Risk:** The previous implementation exported the entire application state raw via `JSON.stringify`. If any sensitive properties (like authentication tokens, user PII, or secrets) were ever added to the application state, they would be written in plaintext to the exported JSON file on the user's filesystem, posing a data leakage risk.

🛡️ **Solution:** The fix introduces a custom `replacer` function in the `JSON.stringify` call. This function scans object keys against a regular expression pattern for common sensitive fields (`/(password|token|secret|auth|key|credential|cookie)/i`). If a matching key with a string value is found, its value is replaced with `"[REDACTED]"`. This ensures that even if sensitive properties are added to the state in the future, they won't be exposed when the debug info is exported. Unit tests were also added to verify this redaction behavior.

---
*PR created automatically by Jules for task [8989559521335760824](https://jules.google.com/task/8989559521335760824) started by @morinatsu*