### PR TITLE
🧹 [code health] Strongly type groupProps to remove any cast

### DIFF
--- a/src/components/Shape.tsx
+++ b/src/components/Shape.tsx
@@ -33,8 +33,8 @@ const Shape: React.FC<ShapeProps> = ({
   const { dispatch, wasDraggedRef } = context;
 
   // Event handlers and ID are attached to the parent group.
-  const groupProps = {
-    onClick: (e: React.MouseEvent) => {
+  const groupProps: React.SVGProps<SVGGElement> & { 'data-shape-id': string } = {
+    onClick: (e: React.MouseEvent<SVGGElement, MouseEvent>) => {
       if (wasDraggedRef.current) {
         wasDraggedRef.current = false;
         return;
@@ -65,8 +65,7 @@ const Shape: React.FC<ShapeProps> = ({
 
   if ('rotation' in shape && shape.rotation !== 0) {
     const center = getShapeCenter(shape);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (groupProps as any).transform = `rotate(${shape.rotation} ${center.x} ${center.y})`;
+    groupProps.transform = `rotate(${shape.rotation} ${center.x} ${center.y})`;
   }
 
   // Props for the hitbox element, which is responsible for capturing all pointer events.


### PR DESCRIPTION
🎯 **What:** Removed the use of the `any` cast and the ESLint disable comment for the `groupProps` object in `src/components/Shape.tsx`.
💡 **Why:** Strongly typing `groupProps` natively allows adding the optional `transform` property safely without bypassing TypeScript's static type checker, thereby improving code safety and maintainability.
✅ **Verification:** Verified by running `pnpm run lint` and `pnpm run build` which passed without issues. Also ran `pnpm run test` and `pnpm run test:e2e` to ensure no functionality is broken.
✨ **Result:** Improved type safety in `src/components/Shape.tsx` while achieving cleaner and more idiomatic React code.

---
*PR created automatically by Jules for task [3423756165776188355](https://jules.google.com/task/3423756165776188355) started by @morinatsu*