### PR TITLE
fix: correct drag resizing behavior of rotated lines

### DIFF
--- a/src/state/reducers/resizingReducer.test.ts
+++ b/src/state/reducers/resizingReducer.test.ts
@@ -300,6 +300,88 @@ describe('resizingReducer', () => {
     expect(newLine.y2).toBe(150);
   });
 
+  it('should resize a rotated line (start handle)', () => {
+    // Initial line: (100, 100) to (200, 100) in local, rotated 45 around center (150, 100)
+    // Global fixed point (end): x2=185.355339, y2=135.355339
+    const line: LineData = {
+      id: '1',
+      type: 'line',
+      x1: 100,
+      y1: 100,
+      x2: 200,
+      y2: 100,
+      rotation: 45,
+    };
+
+    const state: AppState = {
+      ...initialState,
+      shapes: [line],
+      mode: 'resizing',
+      resizingState: {
+        shapeId: '1',
+        handle: 'start',
+        startX: 114.64466,
+        startY: 64.64466,
+        initialShape: line,
+      },
+    };
+
+    const action: Action = {
+      type: 'RESIZE_SHAPE',
+      payload: { x: 100, y: 50, shiftKey: false },
+    };
+
+    const newState = resizingReducer(state, action);
+    const newLine = newState.shapes[0] as LineData;
+
+    expect(newLine.rotation).toBe(0);
+    expect(newLine.x1).toBe(100);
+    expect(newLine.y1).toBe(50);
+    expect(newLine.x2).toBeCloseTo(185.355);
+    expect(newLine.y2).toBeCloseTo(135.355);
+  });
+
+  it('should resize a rotated line (end handle)', () => {
+    // Initial line: (100, 100) to (200, 100) in local, rotated 45 around center (150, 100)
+    // Global fixed point (start): x1=114.64466, y1=64.64466
+    const line: LineData = {
+      id: '1',
+      type: 'line',
+      x1: 100,
+      y1: 100,
+      x2: 200,
+      y2: 100,
+      rotation: 45,
+    };
+
+    const state: AppState = {
+      ...initialState,
+      shapes: [line],
+      mode: 'resizing',
+      resizingState: {
+        shapeId: '1',
+        handle: 'end',
+        startX: 185.355339,
+        startY: 135.355339,
+        initialShape: line,
+      },
+    };
+
+    const action: Action = {
+      type: 'RESIZE_SHAPE',
+      payload: { x: 220, y: 150, shiftKey: false },
+    };
+
+    const newState = resizingReducer(state, action);
+    const newLine = newState.shapes[0] as LineData;
+
+    expect(newLine.rotation).toBe(0);
+    expect(newLine.x1).toBeCloseTo(114.644);
+    expect(newLine.y1).toBeCloseTo(64.644);
+    expect(newLine.x2).toBe(220);
+    expect(newLine.y2).toBe(150);
+  });
+
   it('should maintain aspect ratio when shift key is pressed (SE handle)', () => {
     const rect: RectangleData = {
       id: '1',

--- a/src/state/reducers/resizingReducer.ts
+++ b/src/state/reducers/resizingReducer.ts
@@ -1,6 +1,6 @@
 // src/state/reducers/resizingReducer.ts
 import type { AppState, Action, RectangleData, EllipseData, LineData } from '../../types';
-import { getShapeCenter, toLocal, toGlobal } from '../../utils/geometry';
+import { getShapeCenter, toLocal, toGlobal, rotatePoint } from '../../utils/geometry';
 
 export const resizingReducer = (state: AppState, action: Action): AppState => {
   switch (action.type) {
@@ -30,10 +30,25 @@ export const resizingReducer = (state: AppState, action: Action): AppState => {
       // Handle Line resizing (simpler case)
       if (initialShape.type === 'line') {
         const line = newShape as LineData;
+        const rotation = initialShape.rotation || 0;
+        const center = getShapeCenter(initialShape);
+
+        // Calculate the global coordinates of the fixed point before starting dragging
+        const fixedLocal =
+          handle === 'start'
+            ? { x: initialShape.x2, y: initialShape.y2 }
+            : { x: initialShape.x1, y: initialShape.y1 };
+        const fixedGlobal = rotatePoint(fixedLocal, center, rotation);
+
+        line.rotation = 0; // Reset rotation so the coordinates are absolute/global
         if (handle === 'start') {
           line.x1 = mouseX;
           line.y1 = mouseY;
+          line.x2 = fixedGlobal.x;
+          line.y2 = fixedGlobal.y;
         } else if (handle === 'end') {
+          line.x1 = fixedGlobal.x;
+          line.y1 = fixedGlobal.y;
           line.x2 = mouseX;
           line.y2 = mouseY;
         }


### PR DESCRIPTION
線の端をドラッグしたときの移動が、おかしかったのを修正。
ドラッグしていない端も動くなど、直感に逆らう挙動になっていた。