### PR TITLE
fix: record resizing operation in undo/redo history (#73)

### DIFF
--- a/src/state/historyReducer.test.ts
+++ b/src/state/historyReducer.test.ts
@@ -350,4 +350,84 @@ describe('historyReducer (undoable)', () => {
     const finalState = historyReducer(stateWithDrawing, { type: 'STOP_ROTATING' });
     expect(finalState.past).toHaveLength(0);
   });
+
+  it('UNDO: should only undo the last resize operation, not the shape creation', () => {
+    // 1. Add a shape. This creates the first history entry.
+    const stateWithDrawing: HistoryState = {
+      ...initialState,
+      present: {
+        ...initialState.present,
+        drawingState: {
+          type: 'rectangle',
+          x: 10,
+          y: 10,
+          width: 50,
+          height: 50,
+          startX: 10,
+          startY: 10,
+        },
+      },
+    };
+    let state = historyReducer(stateWithDrawing, { type: 'END_DRAWING' });
+
+    expect(state.past).toHaveLength(1);
+    expect(state.present.shapes).toHaveLength(1);
+    const shapeId = state.present.shapes[0].id;
+    const initialShape = state.present.shapes[0];
+
+    // 2. Resize the shape
+    // 2a. Start resizing.
+    const startResizeAction = {
+      type: 'START_RESIZING' as const,
+      payload: {
+        shapeId,
+        handle: 'se' as const,
+        startX: 60,
+        startY: 60,
+        initialShape,
+      },
+    };
+    state = historyReducer(state, startResizeAction);
+    const shapesBeforeResize = state.present.shapes;
+
+    // 2b. Resize shape.
+    const resizeShapeAction = {
+      type: 'RESIZE_SHAPE' as const,
+      payload: { x: 100, y: 100, shiftKey: false },
+    };
+    state = historyReducer(state, resizeShapeAction);
+
+    // 2c. Stop resizing.
+    const stopResizeAction = { type: 'STOP_RESIZING' as const };
+    state = historyReducer(state, stopResizeAction);
+
+    expect(state.past).toHaveLength(2); // History should contain: [initial_empty, pre-resize_state]
+    expect(state.past[1]).toEqual(shapesBeforeResize);
+
+    // Check if the shape has resized.
+    const resizedShape = state.present.shapes[0] as Extract<ShapeData, { type: 'rectangle' }>;
+    expect(resizedShape.width).not.toBe(50);
+
+    // 3. Perform UNDO
+    const finalState = historyReducer(state, { type: 'UNDO' });
+
+    // 4. Assert the outcome
+    expect(finalState.present.shapes).toHaveLength(1);
+    const undidShape = finalState.present.shapes[0] as Extract<ShapeData, { type: 'rectangle' }>;
+    expect(undidShape.width).toBe(50); // Back to original size
+  });
+
+  it('should not record STOP_RESIZING history if shapes did not change', () => {
+    const stateWithDrawing: HistoryState = {
+      ...initialState,
+      present: {
+        ...initialState.present,
+        shapes: [dummyShape],
+        shapesBeforeResize: [dummyShape],
+      },
+    };
+
+    const finalState = historyReducer(stateWithDrawing, { type: 'STOP_RESIZING' });
+    expect(finalState.past).toHaveLength(0);
+  });
 });

--- a/src/state/historyReducer.ts
+++ b/src/state/historyReducer.ts
@@ -70,6 +70,7 @@ const recordableActions = new Set<string>([
   'FINISH_TEXT_EDIT',
   'STOP_DRAGGING',
   'STOP_ROTATING',
+  'STOP_RESIZING',
 ]);
 
 // Higher-order reducer to add undo/redo functionality
@@ -167,6 +168,18 @@ export const undoable = (reducer: typeof originalReducer) => {
           if (shapesBeforeRotation && !isEqual(shapesBeforeRotation, present.shapes)) {
             return {
               past: [...past, shapesBeforeRotation], // Push the state BEFORE rotation
+              present: newPresent,
+              future: [],
+            };
+          }
+          return { ...state, present: newPresent };
+        }
+
+        if (action.type === 'STOP_RESIZING') {
+          const shapesBeforeResize = present.shapesBeforeResize;
+          if (shapesBeforeResize && !isEqual(shapesBeforeResize, present.shapes)) {
+            return {
+              past: [...past, shapesBeforeResize], // Push the state BEFORE resize
               present: newPresent,
               future: [],
             };

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -21,6 +21,7 @@ export const initialState: AppState = {
   draggingState: null,
   shapesBeforeDrag: null,
   shapesBeforeRotation: null,
+  shapesBeforeResize: null,
   rotatingState: null,
   resizingState: null,
   contextMenu: null,

--- a/src/state/reducers/resizingReducer.ts
+++ b/src/state/reducers/resizingReducer.ts
@@ -9,6 +9,7 @@ export const resizingReducer = (state: AppState, action: Action): AppState => {
       return {
         ...state,
         mode: 'resizing',
+        shapesBeforeResize: state.shapes,
         resizingState: {
           shapeId,
           handle,
@@ -198,6 +199,7 @@ export const resizingReducer = (state: AppState, action: Action): AppState => {
         ...state,
         mode: 'idle',
         resizingState: null,
+        shapesBeforeResize: null,
       };
     }
     default:

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,7 @@ export interface AppState {
   } | null;
   shapesBeforeDrag: ShapeData[] | null;
   shapesBeforeRotation: ShapeData[] | null;
+  shapesBeforeResize: ShapeData[] | null;
   rotatingState: {
     shapeId: string;
     centerX: number;


### PR DESCRIPTION
Closes #73

This PR registers `'STOP_RESIZING'` as a recordable action, and stores the state snapshot before resizing (`shapesBeforeResize`) into the history so that users can undo/redo their resizing operations.

*(Re-created from clean main branch)*