### PR TITLE
🧹 [Code Health] Remove unused code in useInteractionManager tests

### DIFF
--- a/src/hooks/useInteractionManager.test.ts
+++ b/src/hooks/useInteractionManager.test.ts
@@ -22,7 +22,6 @@ describe('useInteractionManager', () => {
   let svgRef: React.RefObject<SVGSVGElement | null>;
   let wasDraggedRef: React.MutableRefObject<boolean>;
   let addEventListenerSpy: ReturnType<typeof vi.fn>;
-  // let removeEventListenerSpy: ReturnType<typeof vi.fn>; // Unused
   let svgAddEventListenerSpy: ReturnType<typeof vi.fn>;
   let svgRemoveEventListenerSpy: ReturnType<typeof vi.fn>;
 
@@ -64,7 +63,6 @@ describe('useInteractionManager', () => {
 
     // Mock global addEventListener
     addEventListenerSpy = vi.spyOn(window, 'addEventListener');
-    // removeEventListenerSpy = vi.spyOn(window, 'removeEventListener'); // Unused
   });
 
   afterEach(() => {


### PR DESCRIPTION
🎯 **What:** Removed commented-out dead code (`removeEventListenerSpy`) in `src/hooks/useInteractionManager.test.ts`.
💡 **Why:** The commented-out code creates unnecessary noise and clutter without contributing to the tests' functionality or behavior, so removing it improves code maintainability and readability.
✅ **Verification:** Verified the fix by successfully running the unit test suite (`pnpm run test src/hooks/useInteractionManager.test.ts`) to ensure no syntax errors or regressions were introduced.
✨ **Result:** The code is cleaner, more readable, and retains all previous functionality.

---
*PR created automatically by Jules for task [1525186720416555134](https://jules.google.com/task/1525186720416555134) started by @morinatsu*