### PR TITLE
🧪 test: improve Text component style assertions

### DIFF
--- a/src/components/shapes/Text.test.tsx
+++ b/src/components/shapes/Text.test.tsx
@@ -104,6 +104,51 @@ describe('Text component', () => {
     expect(textElement).toHaveStyle({ pointerEvents: 'none' });
   });
 
+  it('spreads groupProps to the wrapping <g> element', () => {
+    const customGroupProps = {
+      'data-testid': 'custom-group',
+      id: 'group-id',
+      className: 'group-class',
+    };
+    const { getByTestId } = render(
+      <svg>
+        <Text {...defaultProps} groupProps={customGroupProps} />
+      </svg>,
+    );
+
+    const group = getByTestId('custom-group');
+    expect(group).toHaveAttribute('id', 'group-id');
+    expect(group).toHaveAttribute('class', 'group-class');
+  });
+
+  it('handles empty content correctly', () => {
+    const emptyShape: TextData = {
+      ...defaultShape,
+      content: '',
+    };
+    const { container } = render(
+      <svg>
+        <Text {...defaultProps} shape={emptyShape} />
+      </svg>,
+    );
+
+    const tspans = container.querySelectorAll('tspan');
+    expect(tspans.length).toBe(1);
+    expect(tspans[0]).toHaveTextContent('');
+    expect(tspans[0]).toHaveAttribute('dy', '0');
+  });
+
+  it('disables pointer events when both dragging and drawing mode are true', () => {
+    const { container } = render(
+      <svg>
+        <Text {...defaultProps} isDragging={true} isDrawingMode={true} />
+      </svg>,
+    );
+
+    const textElement = container.querySelector('text');
+    expect(textElement).toHaveStyle({ pointerEvents: 'none' });
+  });
+
   it('disables pointer events when in drawing mode', () => {
     const { container } = render(
       <svg>

--- a/src/components/shapes/Text.test.tsx
+++ b/src/components/shapes/Text.test.tsx
@@ -42,8 +42,12 @@ describe('Text component', () => {
     expect(textElement).toHaveAttribute('fill', 'black');
     expect(textElement).toHaveAttribute('stroke', 'none');
 
-    // Pointer events are "all" when not dragging/drawing
-    expect(textElement).toHaveStyle({ pointerEvents: 'all' });
+    // Check styles including pointer events, cursor, and user-select
+    expect(textElement).toHaveStyle({
+      pointerEvents: 'all',
+      cursor: 'grab',
+      userSelect: 'none',
+    });
 
     const tspans = container.querySelectorAll('tspan');
     expect(tspans.length).toBe(1);


### PR DESCRIPTION
🎯 **What:** Missing tests for the Text component's visual and interactive styles (`cursor: 'grab'` and `userSelect: 'none'`) have been addressed.
📊 **Coverage:** The default props test now covers the `cursor` and `userSelect` styles alongside `pointerEvents`.
✨ **Result:** Improved test coverage and assurance that interaction styles map correctly from component props.

---
*PR created automatically by Jules for task [1411702333619179829](https://jules.google.com/task/1411702333619179829) started by @morinatsu*