### PR TITLE
🧪 test: improve coverage for Text component

### DIFF
--- a/src/components/shapes/Text.test.tsx
+++ b/src/components/shapes/Text.test.tsx
@@ -159,4 +159,45 @@ describe('Text component', () => {
     const textElement = container.querySelector('text');
     expect(textElement).toHaveStyle({ pointerEvents: 'none' });
   });
+
+  it('renders correctly when selected and dragging', () => {
+    const { container } = render(
+      <svg>
+        <Text {...defaultProps} isSelected={true} isDragging={true} />
+      </svg>,
+    );
+
+    const textElement = container.querySelector('text');
+    expect(textElement).toHaveAttribute('fill', 'blue');
+    expect(textElement).toHaveStyle({ pointerEvents: 'none' });
+  });
+
+  it('renders correctly when selected and in drawing mode', () => {
+    const { container } = render(
+      <svg>
+        <Text {...defaultProps} isSelected={true} isDrawingMode={true} />
+      </svg>,
+    );
+
+    const textElement = container.querySelector('text');
+    expect(textElement).toHaveAttribute('fill', 'blue');
+    expect(textElement).toHaveStyle({ pointerEvents: 'none' });
+  });
+
+  it('renders correctly when selected, dragging, and in drawing mode', () => {
+    const { container } = render(
+      <svg>
+        <Text
+          {...defaultProps}
+          isSelected={true}
+          isDragging={true}
+          isDrawingMode={true}
+        />
+      </svg>,
+    );
+
+    const textElement = container.querySelector('text');
+    expect(textElement).toHaveAttribute('fill', 'blue');
+    expect(textElement).toHaveStyle({ pointerEvents: 'none' });
+  });
 });


### PR DESCRIPTION
🎯 **What:** Added missing explicit test coverage for the `Text` component focusing on un-tested prop permutations involving `isSelected`, `isDragging`, and `isDrawingMode` flags.
📊 **Coverage:** Specifically added tests for:
  - `isSelected=true` & `isDragging=true`
  - `isSelected=true` & `isDrawingMode=true`
  - `isSelected=true`, `isDragging=true`, & `isDrawingMode=true`
✨ **Result:** Improved test reliability by fully covering the state combinations, ensuring correct component styling (e.g., `fill` and `pointerEvents` attributes) under all interactive edge cases.

---
*PR created automatically by Jules for task [1563353156058207850](https://jules.google.com/task/1563353156058207850) started by @morinatsu*